### PR TITLE
Correct expected name of database container

### DIFF
--- a/web/dynitag/instance/config.py
+++ b/web/dynitag/instance/config.py
@@ -7,7 +7,7 @@ db_port = os.environ.get("DYNITAG_DB_PORT_5432_TCP_PORT") # port of the linked p
 DEBUG = True
 WTF_CSRF_ENABLED = True
 SECRET_KEY = 'this-really-needs-to-be-changed'
-SQLALCHEMY_DATABASE_URI = "postgresql://myuser:mypassword@{0}:{1}/annotator_db".format(db_ip, db_port)
+SQLALCHEMY_DATABASE_URI = "postgresql://myuser:mypassword@{0}:{1}/dynitag_db".format(db_ip, db_port)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 # Bcrypt algorithm hashing rounds

--- a/web/dynitag/instance/config.py
+++ b/web/dynitag/instance/config.py
@@ -1,8 +1,8 @@
 import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
-db_ip = os.environ.get("ANNOTATOR_DB_PORT_5432_TCP_ADDR") # ip of the linked postgres container (<linked container name>_PORT_<num port>_<protocol>_ADDR)
-db_port = os.environ.get("ANNOTATOR_DB_PORT_5432_TCP_PORT") # port of the linked postgres container (<linked container name>_PORT_<num port>_<protocol>_ADDR)
+db_ip = os.environ.get("DYNITAG_DB_PORT_5432_TCP_ADDR") # ip of the linked postgres container (<linked container name>_PORT_<num port>_<protocol>_ADDR)
+db_port = os.environ.get("DYNITAG_DB_PORT_5432_TCP_PORT") # port of the linked postgres container (<linked container name>_PORT_<num port>_<protocol>_ADDR)
 
 DEBUG = True
 WTF_CSRF_ENABLED = True


### PR DESCRIPTION
When setting up dynitag according to the README, the `docker exec dynitag flask db migrate` will fail with:
```Traceback (most recent call last):
  File "/usr/local/bin/flask", line 11, in <module>
    sys.exit(main())
  [...]
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/url.py", line 60, in __init__
    self.port = int(port)
ValueError: invalid literal for int() with base 10: 'None'
```
This PR fixes this.